### PR TITLE
[Fix]: 앱 시작후 알림 관련, 메인에서 업데이트해주는 알림 관련 문제 해결했습니다.

### DIFF
--- a/Weather_Fairy/Weather_Fairy/Notification/Notification.swift
+++ b/Weather_Fairy/Weather_Fairy/Notification/Notification.swift
@@ -27,7 +27,7 @@ class NotificationForWeather_Fairy {
             let calendar = Calendar.current
             let components = calendar.dateComponents([.hour, .minute], from: now)
             if (0 ..< 24).contains(components.hour!) {
-                notificationForWeather(title: "ウェザ フェアリー(웨쟈 페아리)", body: "오늘 날씨를 확인해보세요 !")
+                notificationForOpening(title: "ウェザ フェアリー(웨쟈 페아리)", body: "오늘 날씨를 확인해보세요 !")
                 self.timer?.invalidate()
             }
         }
@@ -237,6 +237,24 @@ class NotificationForWeather_Fairy {
 
     // MARK: - 알람 배너 설정 배너 내용-트리거-생성
 
+    func notificationForOpening(title: String, body: String) {
+        let pushNotification = UNMutableNotificationContent()
+        pushNotification.title = title
+        pushNotification.body = body
+        pushNotification.sound = UNNotificationSound.default
+
+        // let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0, repeats: false )
+        let request = UNNotificationRequest(identifier: "opening", content: pushNotification, trigger: nil)
+
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error = error {
+                print(" 푸시 알림 Error: \(error.localizedDescription) ")
+            } else {
+                print(" 오프닝 푸시 알림 ON ")
+            }
+        }
+    }
+    
     func notificationForWeather(title: String, body: String) {
         let pushNotification = UNMutableNotificationContent()
         pushNotification.title = title
@@ -250,7 +268,7 @@ class NotificationForWeather_Fairy {
             if let error = error {
                 print(" 푸시 알림 Error: \(error.localizedDescription) ")
             } else {
-                print(" 푸시 알림 ON ")
+                print(" 메인페이지 푸시 알림 ON ")
             }
         }
     }

--- a/Weather_Fairy/Weather_Fairy/Resources/AppDelegate.swift
+++ b/Weather_Fairy/Weather_Fairy/Resources/AppDelegate.swift
@@ -1,6 +1,7 @@
 import UIKit
 import UserNotifications
 
+let notificationForWeather_Fairy = NotificationForWeather_Fairy()
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
@@ -13,6 +14,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 print("로컬 푸시 알림 권한이 거부")
             }
         }
+        notificationForWeather_Fairy.openingNotification()
+
         return true
     }
 
@@ -29,17 +32,6 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     // 알림이 표시될 때 (앱이 활성/비활성 상태와 관계없이 표시)
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         completionHandler([.banner, .sound, .badge, .list])
-
-        func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-            UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, _ in
-                if granted {
-                    print("로컬 알림 권한 허용됨")
-                } else {
-                    print("로컬 알림 권한 거부됨")
-                }
-            }
-            return true
-        }
     }
 
 //     푸시 알림을 클릭시
@@ -47,9 +39,9 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         completionHandler()
     }
 
-    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
-        let newContent = response.notification.request.content.mutableCopy() as! UNMutableNotificationContent
-        newContent.body = "사용자 정의 알림 메시지"
-        contentHandler(newContent)
-    }
+//    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
+//        let newContent = response.notification.request.content.mutableCopy() as! UNMutableNotificationContent
+//        newContent.body = "사용자 정의 알림 메시지"
+//        contentHandler(newContent)
+//    }
 }

--- a/Weather_Fairy/Weather_Fairy/Resources/SceneDelegate.swift
+++ b/Weather_Fairy/Weather_Fairy/Resources/SceneDelegate.swift
@@ -105,7 +105,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             if let error = error {
                 print("푸시 알림 Error: \(error.localizedDescription)")
             } else {
-                print("푸시 알림 ON")
+                print("일간 오전 오후 푸시 알림 ON")
             }
         }
     }
@@ -117,7 +117,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         backgroundNotification.body = body
         backgroundNotification.sound = UNNotificationSound.default
 
-        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 60, repeats: true) //1분마다 실시간 백그라운드 알림 한시간 간격으로 하기위한건대 테스트겸 1분으로 해둠
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 3600, repeats: true) //1분마다 실시간 백그라운드 알림 한시간 간격으로 하기위한건대 테스트겸 1분으로 해둠
 
         let request = UNNotificationRequest(identifier: "APIforNotificationForWeather_Fairy", content: backgroundNotification, trigger: trigger)
 
@@ -125,7 +125,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             if let error = error {
                 print("푸시 알림 Error: \(error.localizedDescription)")
             } else {
-                print("푸시 알림 ON")
+                print("백그라운드 실시간 온도 한시간 간격 푸시 알림 ON")
             }
         }
     }

--- a/Weather_Fairy/Weather_Fairy/View/MainViewController.swift
+++ b/Weather_Fairy/Weather_Fairy/View/MainViewController.swift
@@ -38,7 +38,7 @@ class MainViewController: UIViewController, MiddleViewDelegate {
         locationManager.desiredAccuracy = kCLLocationAccuracyBest
         locationManager.requestWhenInUseAuthorization()
         locationManager.startUpdatingLocation()
-        notificationForWeather_Fairy.openingNotification()
+        //notificationForWeather_Fairy.openingNotification()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -138,7 +138,7 @@ class MainViewController: UIViewController, MiddleViewDelegate {
         if let currentWeatherData = currentWeatherData { // for notificiation
             let currentTemperature = Int(currentWeatherData.main.temp) // for notificiation
             let currentHumide = Int(currentWeatherData.main.humidity) // for notification -humide
-            notificationForWeather_Fairy.showTemperatureAlert(temperature: currentTemperature, humide: currentHumide) // for notificiation
+            //notificationForWeather_Fairy.showTemperatureAlert(temperature: currentTemperature, humide: currentHumide) // for notificiation
         } // for notificiation
     }
 }


### PR DESCRIPTION
앱이 시작한후에 딱 한번만 보여주고 더이상 쓰일필요없는 알림이 첫패이지로 다시 돌아갈때마다 재실행되던것을 해결 서치후 셀클릭시 메인에 반영되고 메인에서 한번만 보여줄 알람이 뷰가 리로드될때마다 재실행되던것을 해결 각 알림 생성관련된 func들  햇갈리지않게 생성부분 추가 수정 해두었습니다(콘솔창에서 해당 알림이 실행될때 구분이 쉽게됩니다)